### PR TITLE
Include panel name in mapped_df

### DIFF
--- a/R/panel.R
+++ b/R/panel.R
@@ -375,6 +375,7 @@ as.data.frame.homogenized_panel <- function(x, ...) {
   structure(
     x$data,
     class = c("mapped_df", class(x$data)),
+    panel_name = x$name,
     mapping = x$mapping,
     id_col = x$id_col,
     waves_col = x$waves_col

--- a/tests/testthat/test-homogenization.R
+++ b/tests/testthat/test-homogenization.R
@@ -124,6 +124,7 @@ test_that("Coding homogenization works", {
 
   panel_df <- as.data.frame(homogenized_panel)
 
+  expect_true(inherits(panel_df, "mapped_df"))
   expect_true(identical(attr(panel_df, "panel_name"), homogenized_panel$name))
   expect_true(identical(attr(panel_df, "mapping"), panel_map))
 })

--- a/tests/testthat/test-homogenization.R
+++ b/tests/testthat/test-homogenization.R
@@ -1,4 +1,4 @@
-context("homogenization")
+context("Homogenization")
 
 test_that("Variable name homogenization works", {
   ids_1 <- sample(1:500, 100)
@@ -118,4 +118,12 @@ test_that("Coding homogenization works", {
       )
     )
   }
+
+  homogenized_panel <- bind_waves(panel)
+  expect_true(inherits(homogenized_panel, "homogenized_panel"))
+
+  panel_df <- as.data.frame(homogenized_panel)
+
+  expect_true(identical(attr(panel_df, "panel_name"), homogenized_panel$name))
+  expect_true(identical(attr(panel_df, "mapping"), panel_map))
 })


### PR DESCRIPTION
Ensures that the other packages can understand the required `tk_panel` information for extendability. 