### PR TITLE
Fix bug where partial homogenization included missing waves

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: panelcleaner
 Title: An interactive interface to homogenize messy panel data into a long format
-Version: 0.0.1.9000
+Version: 0.0.2
 Authors@R: 
     c(person(
             given = "Patrick",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,7 @@ Suggests:
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1
 URL: https://github.com/Global-TIES-for-Children/panelcleaner
 BugReports: https://github.com/Global-TIES-for-Children/panelcleaner/issues
 Depends: 

--- a/R/homogenization.R
+++ b/R/homogenization.R
@@ -7,6 +7,8 @@
 #' @param panel An unhomogenized panel
 #' @param mapping A panel mapping. If NULL, a panel mapping must be attached
 #'   to the `panel` object using `add_mapping()`
+#' @param allow_issues If `TRUE`, will allow waves to be bound together even if
+#'   there are identified issues. Use caution with this!
 #' @param ... Parameters to be used for context, usually for defining a panel
 #'   schema
 #' @return An `unhomogenized_panel` that is ready to be homogenized using

--- a/R/panel-mapping.R
+++ b/R/panel-mapping.R
@@ -74,12 +74,17 @@ panel_mapping <- function(df, waves, .schema = list()) {
   structure(
     df,
     class = c("panel_mapping", class(df)),
-    schema = schema
+    schema = schema,
+    waves = waves
   )
 }
 
 panel_mapping_schema <- function(x) {
-  attr(x, "schema")
+  attr(x, "schema",  exact = TRUE)
+}
+
+panel_mapping_waves <- function(x) {
+  attr(x, "waves",  exact = TRUE)
 }
 
 prep_mapping <- function(df) {
@@ -114,6 +119,11 @@ panel_mapping_coding_columns <- function(panel_mapping) {
     homogenized_coding = schema$homogenized_coding,
     wave_codings = grep(
       paste0("^", schema$wave_coding, "_"),
+      names(panel_mapping),
+      value = TRUE
+    ),
+    wave_names = grep(
+      paste0("^", schema$wave_name, "_"),
       names(panel_mapping),
       value = TRUE
     )

--- a/man/homogenize_panel.Rd
+++ b/man/homogenize_panel.Rd
@@ -5,7 +5,7 @@
 \alias{bind_waves}
 \title{Homogenize all waves to consistent structure}
 \usage{
-homogenize_panel(panel, mapping = NULL, allow_issues = FALSE, ...)
+homogenize_panel(panel, mapping = NULL, ...)
 
 bind_waves(panel, allow_issues = FALSE, ...)
 }
@@ -15,11 +15,11 @@ bind_waves(panel, allow_issues = FALSE, ...)
 \item{mapping}{A panel mapping. If NULL, a panel mapping must be attached
 to the \code{panel} object using \code{add_mapping()}}
 
-\item{allow_issues}{A logical flag to halt execution if homogenization issues
-are encountered. A good safeguard to ensure that your data is consistent.}
-
 \item{...}{Parameters to be used for context, usually for defining a panel
 schema}
+
+\item{allow_issues}{If \code{TRUE}, will allow waves to be bound together even if
+there are identified issues. Use caution with this!}
 }
 \value{
 An \code{unhomogenized_panel} that is ready to be homogenized using

--- a/man/panelcleaner-package.Rd
+++ b/man/panelcleaner-package.Rd
@@ -23,7 +23,7 @@ is consistent across all waves.
 Resources for workflow:
 \itemize{
 \item Defining a panel from waves of data: \code{\link[=enpanel]{enpanel()}}, \code{\link[=add_wave]{add_wave()}}
-\item Accessing waves of data from a panel: \code{\link[=wave]{wave()}}
+\item Accessing waves of data from an unhomogenized panel: \code{\link[=wave]{wave()}}
 \item Defining a panel mapping: \code{\link[=panel_mapping]{panel_mapping()}}
 \item Adding a panel mapping to a panel: \code{\link[=add_mapping]{add_mapping()}}
 \item Homogenize a panel: \code{\link[=homogenize_panel]{homogenize_panel()}}

--- a/tests/testthat/test-homogenization.R
+++ b/tests/testthat/test-homogenization.R
@@ -140,3 +140,83 @@ test_that("Coding homogenization works", {
   expect_true(identical(attr(panel_df, "panel_name"), homogenized_panel$name))
   expect_true(identical(attr(panel_df, "mapping"), panel_map))
 })
+
+test_that("Partial homogenization works", {
+  set.seed(1182)
+
+  ids_1 <- sample(1:500, 100)
+  ids_2 <- ids_1
+  ids_2[sample(1:100, 10)] <- sample(500:1000, 10)
+
+  wave_1 <- data.frame(
+    id = ids_1,
+    time = 1,
+    q1 = sample(1:5, 100, replace = TRUE),
+    q2 = sample(1:5, 100, replace = TRUE)
+  )
+
+  wave_2 <- data.frame(
+    id = ids_2,
+    time = 2,
+    question1 = sample(1:5, 100, replace = TRUE),
+    question2 = sample(1:5, 100, replace = TRUE)
+  )
+
+  coding_1 <- bquote(
+    coding(
+      code("Never", 1),
+      code("Rarely", 2),
+      code("Sometimes", 3),
+      code("Frequently", 4),
+      code("Always", 5)
+    )
+  )
+
+  coding_2 <- bquote(
+    coding(
+      code("Never", 5),
+      code("Rarely", 4),
+      code("Sometimes", 3),
+      code("Frequently", 2),
+      code("Always", 1)
+    )
+  )
+
+  coding_h <- bquote(
+    coding(
+      code("Never", 1),
+      code("Rarely", 2),
+      code("Sometimes", 3),
+      code("Frequently", 4),
+      code("Always", 5)
+    )
+  )
+
+  single_deparse <- function(expr) {
+    paste0(deparse(expr), collapse = "")
+  }
+
+  mapping <- tibble::tribble(
+    ~ name_1, ~ coding_1, ~ name_2, ~ coding_2, ~ panel_name, ~ homogenized_name, ~ homogenized_coding,
+    NA_character_, NA_character_, "id", NA_character_, "test_panel", "id", NA_character_,
+    NA_character_, NA_character_, "question1", single_deparse(coding_2), "test_panel", "question_1", single_deparse(coding_h),
+    NA_character_, NA_character_, "question2", single_deparse(coding_2), "test_panel", "question_2", single_deparse(coding_h)
+  )
+
+  panel_map <- panel_mapping(
+    mapping,
+    1:2,
+    .schema = list(
+      wave_name = "name",
+      wave_coding = "coding",
+      panel = "panel_name",
+      homogenized_name = "homogenized_name",
+      homogenized_coding = "homogenized_coding"
+    )
+  )
+
+  panel <-
+    enpanel("test_panel", `2` = wave_2) %>%
+    add_mapping(panel_map) %>%
+    homogenize_panel()
+})

--- a/tests/testthat/test-homogenization.R
+++ b/tests/testthat/test-homogenization.R
@@ -218,5 +218,10 @@ test_that("Partial homogenization works", {
   panel <-
     enpanel("test_panel", `2` = wave_2) %>%
     add_mapping(panel_map) %>%
-    homogenize_panel()
+    homogenize_panel() %>%
+    bind_waves()
+
+  panel_dat <- as.data.frame(panel)
+  expect_true(setequal(unique(panel_dat$wave), "2"))
+  expect_true(setequal(unique(panel_dat$question_2), 1:5))
 })


### PR DESCRIPTION
If a variable does not exist in one wave but existed in others, the coding homogenization routine would interpret the missing wave as incomplete (missing coding information, rather than the variable being absent altogether) and halt the homogenization process. To rectify this, an additional filter for non-missing variable names was provided to determine which codings are truly missing or part of a missing variable.