### PR TITLE
fix: allow missing vars in homogenization

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: panelcleaner
 Title: An interactive interface to homogenize messy panel data into a long format
-Version: 0.0.3
+Version: 0.0.4
 Authors@R: 
     c(person(
             given = "Patrick",

--- a/R/homogenization.R
+++ b/R/homogenization.R
@@ -319,9 +319,13 @@ homogenize_wave_names <- function(panel, w, long_map, ctx = list()) {
       ))
     } else {
       issue <- list(missing_vars)
-      names(issue) <- glue("missing_raw_vars_{w}")
+      names(issue) <- glue("missing_raw_variables_{w}")
 
       panel <- add_issues(panel, issue)
+
+      # Subset to known variables
+      long_map <- long_map[long_map[[schema$wave_name]] %in% names(wave_db), ]
+      variables <- variables[variables %in% names(wave_db)]
     }
   }
 
@@ -332,7 +336,7 @@ homogenize_wave_names <- function(panel, w, long_map, ctx = list()) {
 }
 
 long_map_subset <- function(mapping, columns) {
-  map_subset <- dplyr::select(mapping, columns)
+  map_subset <- dplyr::select(mapping, dplyr::all_of(columns))
   wave_tags <- panel_mapping_waves(mapping)
 
   tidyr::pivot_longer(


### PR DESCRIPTION
There was a bug where panelcleaner would not subset the variables to
those that are present in the wave database if the user wants to allow
missing variables to not stop homogenization.
