### PR TITLE
fix: allow coding homogenization on missing vars

### DIFF
--- a/R/homogenization.R
+++ b/R/homogenization.R
@@ -278,6 +278,10 @@ homogenize_wave_descriptions <- function(panel, w, long_map, ctx = list()) {
   long_map <- long_map[!is.na(long_map[[schema$wave_name]]), ]
 
   wave_db <- wave(panel, w)
+
+  # In case some variables are missing due to error_missing_raw_variables being skipped
+  long_map <- long_map[long_map[[schema$homogenized_name]] %in% names(wave_db), ]
+
   variables <- long_map[[schema$homogenized_name]]
 
   for (v in variables) {

--- a/R/recoding.R
+++ b/R/recoding.R
@@ -18,8 +18,10 @@ coding_mapping <- function(mapping) {
 }
 
 homogenize_wave_codings <- function(panel, w, long_map, ctx = list()) {
+  schema <- panel_mapping_schema(long_map)
+
   long_map <- dplyr::filter(long_map, .data$wave == w)
-  long_map <- dplyr::filter(long_map, !is.na(.data[[panel_mapping_schema(long_map)$homogenized_coding]]))
+  long_map <- dplyr::filter(long_map, !is.na(.data[[schema$homogenized_coding]]))
 
   if (nrow(long_map) < 1) {
     return(panel)
@@ -27,7 +29,10 @@ homogenize_wave_codings <- function(panel, w, long_map, ctx = list()) {
 
   wave_db <- wave(panel, w)
 
-  for (variable in long_map[[panel_mapping_schema(long_map)$homogenized_name]]) {
+  # In case some variables are missing due to error_missing_raw_variables being skipped
+  long_map <- long_map[long_map[[schema$homogenized_name]] %in% names(wave_db), ]
+
+  for (variable in long_map[[schema$homogenized_name]]) {
     func <- variable_recoding_func(variable, panel, long_map, w)
     wave_db[[variable]] <- func(wave_db[[variable]])
   }

--- a/tests/testthat/test-homogenization.R
+++ b/tests/testthat/test-homogenization.R
@@ -43,48 +43,6 @@ test_that("Variable name homogenization works", {
   }
 })
 
-test_that("Missing variables don't stop homogenization, if desired", {
-  ids_1 <- sample(1:500, 100)
-  ids_2 <- ids_1
-  ids_2[sample(1:100, 10)] <- sample(500:1000, 10)
-
-  wave_1 <- data.frame(id = ids_1, time = 1, q1 = sample(1:5, 100, replace = TRUE), q2 = sample(0:1, 100, replace = TRUE), stringsAsFactors = FALSE)
-  wave_2 <- data.frame(id = ids_2, time = 2, question1 = sample(1:5, 100, replace = TRUE), Q2 = sample(0:1, 100, replace = TRUE), stringsAsFactors = FALSE)
-
-  mapping <- tibble::tribble(
-    ~name_t1, ~coding_t1, ~name_t2, ~coding_t2, ~panel_name, ~homogenized_name, ~homogenized_coding,
-    "id", NA_character_, "id", NA_character_, "test_panel", "id", NA_character_,
-    "time", NA_character_, "time", NA_character_, "test_panel", "time", NA_character_,
-    "q1", NA_character_, "question1", NA_character_, "test_panel", "question_1", NA_character_,
-    "q2", NA_character_, "Q2", NA_character_, "test_panel", "question_2", NA_character_,
-    "q3", NA_character_, "q3", NA_character_, "test_panel", "question_3", NA_character_
-  )
-
-  panel_map <- panel_mapping(
-    mapping,
-    c("t1", "t2"),
-    .schema = list(
-      wave_name = "name",
-      wave_coding = "coding",
-      panel = "panel_name",
-      homogenized_name = "homogenized_name",
-      homogenized_coding = "homogenized_coding"
-    )
-  )
-
-  panel <-
-    enpanel("test_panel", t1 = wave_1, t2 = wave_2) %>%
-    add_mapping(panel_map)
-
-  homogenized_panel <- homogenize_panel(panel, error_missing_raw_variables = FALSE)
-
-  expect_true(has_issues(homogenized_panel))
-  expect_identical(
-    names(issues(homogenized_panel)),
-    c("missing_raw_variables_t1", "missing_raw_variables_t2")
-  )
-})
-
 test_that("Coding homogenization works", {
   set.seed(1182)
 
@@ -339,4 +297,80 @@ test_that("description mapping works", {
     class = "tk_error"
   )
   expect_true(grepl("missing descriptions", err$message))
+})
+
+test_that("Missing variables don't stop homogenization, if desired", {
+  ids_1 <- sample(1:500, 100)
+  ids_2 <- ids_1
+  ids_2[sample(1:100, 10)] <- sample(500:1000, 10)
+
+  wave_1 <- data.frame(id = ids_1, time = 1, q1 = sample(1:5, 100, replace = TRUE), q2 = sample(0:1, 100, replace = TRUE), stringsAsFactors = FALSE)
+  wave_2 <- data.frame(id = ids_2, time = 2, question1 = sample(1:5, 100, replace = TRUE), Q2 = sample(0:1, 100, replace = TRUE), stringsAsFactors = FALSE)
+
+  coding_1 <- bquote(
+    coding(
+      code("Never", 1),
+      code("Rarely", 2),
+      code("Sometimes", 3),
+      code("Frequently", 4),
+      code("Always", 5)
+    )
+  )
+
+  coding_2 <- bquote(
+    coding(
+      code("Never", 5),
+      code("Rarely", 4),
+      code("Sometimes", 3),
+      code("Frequently", 2),
+      code("Always", 1)
+    )
+  )
+
+  coding_h <- bquote(
+    coding(
+      code("Never", 1),
+      code("Rarely", 2),
+      code("Sometimes", 3),
+      code("Frequently", 4),
+      code("Always", 5)
+    )
+  )
+
+  single_deparse <- function(expr) {
+    paste0(deparse(expr), collapse = "")
+  }
+
+  mapping <- tibble::tribble(
+    ~name_t1, ~coding_t1, ~name_t2, ~coding_t2, ~panel_name, ~homogenized_name, ~homogenized_coding,
+    "id", NA_character_, "id", NA_character_, "test_panel", "id", NA_character_,
+    "time", NA_character_, "time", NA_character_, "test_panel", "time", NA_character_,
+    "q1", NA_character_, "question1", NA_character_, "test_panel", "question_1", NA_character_,
+    "q2", NA_character_, "Q2", NA_character_, "test_panel", "question_2", NA_character_,
+    "q3", single_deparse(coding_1), "q3", single_deparse(coding_2), "test_panel", "question_3", single_deparse(coding_h)
+  )
+
+  panel_map <- panel_mapping(
+    mapping,
+    c("t1", "t2"),
+    .schema = list(
+      wave_name = "name",
+      wave_coding = "coding",
+      panel = "panel_name",
+      homogenized_name = "homogenized_name",
+      homogenized_coding = "homogenized_coding"
+    )
+  )
+
+  panel <-
+    enpanel("test_panel", t1 = wave_1, t2 = wave_2) %>%
+    add_mapping(panel_map)
+
+  homogenized_panel <- homogenize_panel(panel, error_missing_raw_variables = FALSE)
+
+  expect_true(has_issues(homogenized_panel))
+  expect_identical(
+    names(issues(homogenized_panel)),
+    c("missing_raw_variables_t1", "missing_raw_variables_t2")
+  )
 })


### PR DESCRIPTION
Same issue as the name homogenization but with mutation
