### PR TITLE
feat: add specific error message for duped names

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,4 @@
+# panelcleaner 0.0.4
+
+* Fix bug where panelcleaner would not subset the variables to those that are present in the wave database if the user wants to allow missing variables to not stop homogenization
+* Add specific error message for duplicated names to reduce confusion

--- a/R/panel-mapping.R
+++ b/R/panel-mapping.R
@@ -81,6 +81,10 @@ panel_mapping <- function(df, waves, .schema = list()) {
     }
   }
 
+  for (p in unique(df[[schema$panel]])) {
+    validate_panel(df, p, waves, schema)
+  }
+
   df <- prep_mapping(df)
 
   structure(
@@ -89,6 +93,35 @@ panel_mapping <- function(df, waves, .schema = list()) {
     schema = schema,
     waves = waves
   )
+}
+
+validate_panel <- function(df, p, waves, schema) {
+  df <- df[df[[schema$panel]] == p, ]
+
+  # Don't allow duplicates in names
+  homogenized_names <- df[[schema$homogenized_name]]
+  homogenized_names <- homogenized_names[!is.na(homogenized_names)]
+
+  if (any(duplicated(homogenized_names))) {
+    bad_homogenized_names <- unique(homogenized_names[duplicated(homogenized_names)])
+    bad_homogenized_names <- paste0("- ", bad_homogenized_names, "\n")
+
+    tk_err(c("Duplicated homogenized names encountered in {ui_value(p)}:\n", bad_homogenized_names))
+  }
+
+  for (w in waves) {
+    name_col <- paste0(schema$wave_name, "_", w)
+
+    wave_vars <- df[[name_col]]
+    wave_vars <- wave_vars[!is.na(wave_vars)]
+
+    if (any(duplicated(wave_vars))) {
+      bad_wave_vars <- unique(wave_vars[duplicated(wave_vars)])
+      bad_wave_vars <- paste0("- ", bad_wave_vars, "\n")
+
+      tk_err(c("Duplicated wave names encountered in {ui_value(w)}:\n", bad_wave_vars))
+    }
+  }
 }
 
 panel_mapping_schema <- function(x) {

--- a/tests/testthat/test-panel.R
+++ b/tests/testthat/test-panel.R
@@ -44,3 +44,29 @@ test_that("Basic panel structure holds", {
 
   expect_true(is_panel_mapping(panel_map))
 })
+
+test_that("Variable duplicates are caught correctly", {
+  mapping <- tibble::tribble(
+    ~name_t1, ~coding_t1, ~name_t2, ~coding_t2, ~panel, ~homogenized_name, ~homogenized_coding,
+    "id", NA_character_, "id", NA_character_, "test_panel", "id", NA_character_,
+    "time", NA_character_, "time", NA_character_, "test_panel", "time", NA_character_,
+    "q1", NA_character_, "question1", NA_character_, "test_panel", "question_1", NA_character_,
+    "q1", NA_character_, "Q2", NA_character_, "test_panel", "question_2", NA_character_,
+    "q3", NA_character_, "q3", NA_character_, "test_panel", "question_3", NA_character_
+  )
+
+  err <- expect_error(panel_mapping(mapping, waves = c("t1", "t2")))
+  expect_match(err$message, "^Duplicated wave names")
+
+  mapping <- tibble::tribble(
+    ~name_t1, ~coding_t1, ~name_t2, ~coding_t2, ~panel, ~homogenized_name, ~homogenized_coding,
+    "id", NA_character_, "id", NA_character_, "test_panel", "id", NA_character_,
+    "time", NA_character_, "time", NA_character_, "test_panel", "time", NA_character_,
+    "q1", NA_character_, "question1", NA_character_, "test_panel", "question_1", NA_character_,
+    "q2", NA_character_, "Q2", NA_character_, "test_panel", "question_1", NA_character_,
+    "q3", NA_character_, "q3", NA_character_, "test_panel", "question_3", NA_character_
+  )
+
+  err <- expect_error(panel_mapping(mapping, waves = c("t1", "t2")))
+  expect_match(err$message, "^Duplicated homogenized names")
+})


### PR DESCRIPTION
Previously panelcleaner would silently go by, which could cause
downstream errors that seemed unrelated. This change catches those
errors at the panel mapping level since they don't depend on the data to
be homogenized.
